### PR TITLE
feat: include issue/PR numbers under contribution types

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Additionally, based on PR [conventional commit titles](https://www.conventionalc
 > import { $ } from "execa";
 >
 > for (const [contributor, contributions] of Object.entries(contributors)) {
-> 	await $`npx all-contributors add ${contributor} ${contributions.join(",")}`;
+> 	const contributionTypes = Object.keys(contributions).join(",");
+> 	await $`npx all-contributors add ${contributor} ${contributionTypes}`;
 > }
 > ```
 

--- a/src/Contributor.test.ts
+++ b/src/Contributor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { Contributor } from "./Contributor.js";
+
+describe("Contributor", () => {
+	it("adds a new entry under a type when that type doesn't yet exist", () => {
+		const contributor = new Contributor();
+
+		contributor.add(1, "code");
+
+		expect(contributor.contributions).toEqual({ code: [1] });
+	});
+
+	it("adds a new entry under an existing type when that type already exists", () => {
+		const contributor = new Contributor();
+
+		contributor.add(1, "code");
+		contributor.add(2, "code");
+
+		expect(contributor.contributions).toEqual({ code: [1, 2] });
+	});
+
+	it("adds a new entry under a second type when that type does not already exist", () => {
+		const contributor = new Contributor();
+
+		contributor.add(1, "code");
+		contributor.add(2, "design");
+
+		expect(contributor.contributions).toEqual({ code: [1], design: [2] });
+	});
+});

--- a/src/Contributor.test.ts
+++ b/src/Contributor.test.ts
@@ -8,7 +8,7 @@ describe("Contributor", () => {
 
 		contributor.add(1, "code");
 
-		expect(contributor.contributions).toEqual({ code: [1] });
+		expect(contributor.contributions).toEqual({ code: new Set([1]) });
 	});
 
 	it("adds a new entry under an existing type when that type already exists", () => {
@@ -17,7 +17,7 @@ describe("Contributor", () => {
 		contributor.add(1, "code");
 		contributor.add(2, "code");
 
-		expect(contributor.contributions).toEqual({ code: [1, 2] });
+		expect(contributor.contributions).toEqual({ code: new Set([1, 2]) });
 	});
 
 	it("adds a new entry under a second type when that type does not already exist", () => {
@@ -26,6 +26,9 @@ describe("Contributor", () => {
 		contributor.add(1, "code");
 		contributor.add(2, "design");
 
-		expect(contributor.contributions).toEqual({ code: [1], design: [2] });
+		expect(contributor.contributions).toEqual({
+			code: new Set([1]),
+			design: new Set([2]),
+		});
 	});
 });

--- a/src/Contributor.ts
+++ b/src/Contributor.ts
@@ -1,0 +1,7 @@
+export class Contributor {
+	readonly contributions: Record<string, number[]> = {};
+
+	add(id: number, type: string) {
+		(this.contributions[type] ??= []).push(id);
+	}
+}

--- a/src/Contributor.ts
+++ b/src/Contributor.ts
@@ -1,7 +1,7 @@
 export class Contributor {
-	readonly contributions: Record<string, number[]> = {};
+	readonly contributions: Record<string, Set<number>> = {};
 
-	add(id: number, type: string) {
-		(this.contributions[type] ??= []).push(id);
+	add(number: number, type: string) {
+		(this.contributions[type] ??= new Set()).add(number);
 	}
 }

--- a/src/ContributorsCollection.test.ts
+++ b/src/ContributorsCollection.test.ts
@@ -14,40 +14,40 @@ describe("ContributorsCollection", () => {
 	it("adds a login when it is not ignored", () => {
 		const contributors = new ContributorsCollection(new Set());
 
-		contributors.add("abc", "bug");
+		contributors.add("abc", 0, "bug");
 
 		const actual = contributors.collect();
 
-		expect(actual).toEqual({ abc: ["bug"] });
+		expect(actual).toEqual({ abc: { bug: [0] } });
 	});
 
 	it("adds sorted contributions for logins when they are added in non-alphabetical order ", () => {
 		const contributors = new ContributorsCollection(new Set());
 
-		contributors.add("def", "tool");
-		contributors.add("abc", "tool");
-		contributors.add("abc", "bug");
-		contributors.add("abc", "code");
-		contributors.add("def", "code");
+		contributors.add("def", 1, "tool");
+		contributors.add("abc", 2, "tool");
+		contributors.add("abc", 3, "bug");
+		contributors.add("abc", 4, "code");
+		contributors.add("def", 5, "code");
 
 		const actual = contributors.collect();
 
 		expect(actual).toEqual({
-			abc: ["bug", "code", "tool"],
-			def: ["code", "tool"],
+			abc: { bug: [3], code: [4], tool: [2] },
+			def: { code: [5], tool: [1] },
 		});
 	});
 
 	it("does not add a login contribution when it is ignored ", () => {
 		const contributors = new ContributorsCollection(new Set(["ignored"]));
 
-		contributors.add("abc", "bug");
-		contributors.add("ignored", "code");
+		contributors.add("abc", 1, "bug");
+		contributors.add("ignored", 2, "code");
 
 		const actual = contributors.collect();
 
 		expect(actual).toEqual({
-			abc: ["bug"],
+			abc: { bug: [1] },
 		});
 	});
 });

--- a/src/ContributorsCollection.ts
+++ b/src/ContributorsCollection.ts
@@ -1,23 +1,40 @@
+import { Contributor } from "./Contributor.js";
+
+/**
+ * For a set of logins, the contributions under those users.
+ */
+export type ContributorsContributions = Record<
+	string,
+	ContributorContributions
+>;
+
+/**
+ * For each contribution under a login, the issue/PR numbers that count as that type.
+ */
+export type ContributorContributions = Record<string, number[]>;
+
 export class ContributorsCollection {
-	#contributors: Record<string, Set<string>> = {};
+	#contributors: Record<string, Contributor> = {};
 	#ignoredLogins: Set<string>;
 
 	constructor(ignoredLogins: Set<string>) {
 		this.#ignoredLogins = ignoredLogins;
 	}
 
-	add(login: string | undefined, type: string) {
+	add(login: string | undefined, id: number, type: string) {
 		if (login && !this.#ignoredLogins.has(login)) {
-			(this.#contributors[login.toLowerCase()] ??= new Set()).add(type);
+			(this.#contributors[login.toLowerCase()] ??= new Contributor()).add(
+				id,
+				type
+			);
 		}
 	}
 
-	collect() {
+	collect(): ContributorsContributions {
 		return Object.fromEntries(
 			Object.entries(this.#contributors)
 				.map(
-					([contributor, types]) =>
-						[contributor, Array.from(types).sort()] as const
+					([login, contributor]) => [login, contributor.contributions] as const
 				)
 				.sort(([a], [b]) => a.localeCompare(b))
 		);

--- a/src/ContributorsCollection.ts
+++ b/src/ContributorsCollection.ts
@@ -21,10 +21,10 @@ export class ContributorsCollection {
 		this.#ignoredLogins = ignoredLogins;
 	}
 
-	add(login: string | undefined, id: number, type: string) {
+	add(login: string | undefined, number: number, type: string) {
 		if (login && !this.#ignoredLogins.has(login)) {
 			(this.#contributors[login.toLowerCase()] ??= new Contributor()).add(
-				id,
+				number,
 				type
 			);
 		}
@@ -34,7 +34,18 @@ export class ContributorsCollection {
 		return Object.fromEntries(
 			Object.entries(this.#contributors)
 				.map(
-					([login, contributor]) => [login, contributor.contributions] as const
+					([login, contributor]) =>
+						[
+							login,
+							Object.fromEntries(
+								Object.entries(contributor.contributions).map(
+									([type, numbers]) => [
+										type,
+										Array.from(numbers).sort((a, b) => a - b),
+									]
+								)
+							),
+						] as const
 				)
 				.sort(([a], [b]) => a.localeCompare(b))
 		);

--- a/src/collect/collectEvents.ts
+++ b/src/collect/collectEvents.ts
@@ -2,6 +2,8 @@ import { Octokit } from "octokit";
 
 import { paginate, RequestDefaults } from "./api.js";
 
+export type RepoEvent = Awaited<ReturnType<typeof collectEvents>>[number];
+
 export async function collectEvents(
 	defaults: RequestDefaults,
 	octokit: Octokit

--- a/src/collect/eventIsPullRequestReviewEvent.test.ts
+++ b/src/collect/eventIsPullRequestReviewEvent.test.ts
@@ -6,9 +6,9 @@ describe("eventIsPullRequestReviewEvent", () => {
 	it.each([
 		[{ type: "other" }, false],
 		[{ issue: {}, type: "other" }, false],
-		[{ issue: { id: 1 }, type: "other" }, false],
+		[{ issue: { number: 1 }, type: "other" }, false],
 		[{ type: "PullRequestReviewEvent" }, false],
-		[{ issue: { id: 1 }, type: "PullRequestReviewEvent" }, true],
+		[{ issue: { number: 1 }, type: "PullRequestReviewEvent" }, true],
 	])("when given %j, returns %s", (event, expected) => {
 		const actual = eventIsPullRequestReviewEvent(event);
 

--- a/src/collect/eventIsPullRequestReviewEvent.test.ts
+++ b/src/collect/eventIsPullRequestReviewEvent.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { eventIsPullRequestReviewEvent } from "./eventIsPullRequestReviewEvent.js";
+
+describe("eventIsPullRequestReviewEvent", () => {
+	it.each([
+		[{ type: "other" }, false],
+		[{ issue: {}, type: "other" }, false],
+		[{ issue: { id: 1 }, type: "other" }, false],
+		[{ type: "PullRequestReviewEvent" }, false],
+		[{ issue: { id: 1 }, type: "PullRequestReviewEvent" }, true],
+	])("when given %j, returns %s", (event, expected) => {
+		const actual = eventIsPullRequestReviewEvent(event);
+
+		expect(actual).toBe(expected);
+	});
+});

--- a/src/collect/eventIsPullRequestReviewEvent.ts
+++ b/src/collect/eventIsPullRequestReviewEvent.ts
@@ -2,7 +2,7 @@ import { RepoEvent } from "./collectEvents.js";
 
 type PullRequestReviewEvent = RepoEvent & {
 	issue: {
-		id: number;
+		number: number;
 	};
 };
 
@@ -11,6 +11,6 @@ export function eventIsPullRequestReviewEvent(
 ): event is PullRequestReviewEvent {
 	return (
 		event.type === "PullRequestReviewEvent" &&
-		!!(event as Partial<PullRequestReviewEvent>).issue?.id
+		!!(event as Partial<PullRequestReviewEvent>).issue?.number
 	);
 }

--- a/src/collect/eventIsPullRequestReviewEvent.ts
+++ b/src/collect/eventIsPullRequestReviewEvent.ts
@@ -1,0 +1,16 @@
+import { RepoEvent } from "./collectEvents.js";
+
+type PullRequestReviewEvent = RepoEvent & {
+	issue: {
+		id: number;
+	};
+};
+
+export function eventIsPullRequestReviewEvent(
+	event: Pick<RepoEvent, "type">
+): event is PullRequestReviewEvent {
+	return (
+		event.type === "PullRequestReviewEvent" &&
+		!!(event as Partial<PullRequestReviewEvent>).issue?.id
+	);
+}

--- a/src/collect/index.ts
+++ b/src/collect/index.ts
@@ -42,7 +42,7 @@ export async function collect(
 			if (labels.some((label) => label === labelType)) {
 				contributors.add(
 					acceptedIssue.user?.login,
-					acceptedIssue.id,
+					acceptedIssue.number,
 					contribution
 				);
 			}
@@ -55,7 +55,7 @@ export async function collect(
 		const type = parseMergedPullType(mergedPull.title);
 
 		for (const author of authors) {
-			contributors.add(author, mergedPull.id, type);
+			contributors.add(author, mergedPull.number, type);
 		}
 	}
 
@@ -64,7 +64,7 @@ export async function collect(
 
 	for (const event of issueEvents) {
 		if (event.actor && event.issue) {
-			contributors.add(event.actor.login, event.issue.id, "maintenance");
+			contributors.add(event.actor.login, event.issue.number, "maintenance");
 			maintainers.add(event.actor.login);
 		}
 	}
@@ -76,7 +76,7 @@ export async function collect(
 			eventIsPullRequestReviewEvent(event) &&
 			maintainers.has(event.actor.login)
 		) {
-			contributors.add(event.actor.login, event.issue.id, "review");
+			contributors.add(event.actor.login, event.issue.number, "review");
 		}
 	}
 

--- a/src/createAllContributorsForRepository.ts
+++ b/src/createAllContributorsForRepository.ts
@@ -1,0 +1,13 @@
+import { collect } from "./collect/index.js";
+import {
+	fillInOptions,
+	RawAllContributorsForRepositoryOptions,
+} from "./options.js";
+
+export async function createAllContributorsForRepository(
+	rawOptions: RawAllContributorsForRepositoryOptions
+) {
+	const options = fillInOptions(rawOptions);
+
+	return await collect(options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,5 @@
-import { collect } from "./collect/index.js";
-import {
-	fillInOptions,
-	RawAllContributorsForRepositoryOptions,
-} from "./options.js";
-
-export async function createAllContributorsForRepository(
-	rawOptions: RawAllContributorsForRepositoryOptions
-) {
-	const options = fillInOptions(rawOptions);
-
-	return await collect(options);
-}
+export {
+	ContributorContributions,
+	ContributorsContributions,
+} from "./ContributorsCollection.js";
+export { createAllContributorsForRepository } from "./createAllContributorsForRepository.js";


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #13
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes the output format as suggested in #13:

```diff
{
-  joshuakgoldberg: [ 'maintenance', 'tool' ],
+  joshuakgoldberg: { maintenance: [123], tool: [456, 789] }
}
```