### PR TITLE
fix: correct merged PRs search query

### DIFF
--- a/src/collect/collectMergedPulls.ts
+++ b/src/collect/collectMergedPulls.ts
@@ -9,7 +9,7 @@ export async function collectMergedPulls(
 	return await paginate(defaults, async (options) => {
 		const response = await octokit.request("GET /search/issues", {
 			...options,
-			q: "repo:JoshuaKGoldberg/template-typescript-node-package+is:pr+is:merged",
+			q: `repo:${defaults.owner}/${defaults.repo}+is:pr+is:merged`,
 		});
 
 		return response.data.items;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #28
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the `defaults` object as it should.