### PR TITLE
test: added end-to-end-style unit test

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { getAllContributorsForRepository } from "./index.js";
+
+const mockRequest = (url: string) => {
+	switch (url) {
+		case "GET /repos/{owner}/{repo}/issues":
+			return {
+				data: [
+					{
+						labels: ["type: bug"],
+						number: 111,
+						user: {
+							login: "AcceptedIssueUser",
+						},
+					},
+				],
+			};
+		case "GET /repos/{owner}/{repo}/issues/events":
+			return {
+				data: [
+					{
+						actor: {
+							login: "IssueEventUser",
+						},
+						event: "assigned",
+						issue: {
+							number: 222,
+						},
+					},
+				],
+			};
+		case "GET /search/issues":
+			return {
+				data: {
+					items: [
+						{
+							number: 333,
+							title: "feat: Merged PR",
+							user: {
+								login: "MergedPullUser",
+							},
+						},
+					],
+				},
+			};
+		case "GET /repos/{owner}/{repo}/events":
+			return {
+				data: [
+					{
+						actor: {
+							login: "IssueEventUser",
+						},
+						issue: {
+							number: 222,
+						},
+						type: "PullRequestReviewEvent",
+					},
+				],
+			};
+	}
+};
+
+vi.mock("octokit", () => ({
+	get Octokit() {
+		return class MockOctokit {
+			static defaults = () => MockOctokit;
+
+			request = mockRequest;
+		};
+	},
+}));
+
+describe("end-to-end", () => {
+	test("getAllContributorsForRepository", async () => {
+		const actual = await getAllContributorsForRepository({
+			owner: "TestOwner",
+			repo: "test-repository",
+		});
+
+		expect(actual).toMatchInlineSnapshot(`
+			{
+			  "acceptedissueuser": {
+			    "bug": [
+			      111,
+			    ],
+			  },
+			  "issueeventuser": {
+			    "maintenance": [
+			      222,
+			    ],
+			    "review": [
+			      222,
+			    ],
+			  },
+			  "mergedpulluser": {
+			    "code": [
+			      333,
+			    ],
+			  },
+			}
+		`);
+	});
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,7 +11,7 @@ const mockRequest = (url: string) => {
 						labels: ["type: bug"],
 						number: 111,
 						user: {
-							login: "AcceptedIssueUser",
+							login: "Accepted-Issue-User",
 						},
 					},
 				],
@@ -21,7 +21,7 @@ const mockRequest = (url: string) => {
 				data: [
 					{
 						actor: {
-							login: "IssueEventUser",
+							login: "Issue-Event-User",
 						},
 						event: "assigned",
 						issue: {
@@ -38,7 +38,7 @@ const mockRequest = (url: string) => {
 							number: 333,
 							title: "feat: Merged PR",
 							user: {
-								login: "MergedPullUser",
+								login: "Merged-Pull-User",
 							},
 						},
 					],
@@ -49,12 +49,12 @@ const mockRequest = (url: string) => {
 				data: [
 					{
 						actor: {
-							login: "IssueEventUser",
+							login: "Issue-Event-User",
 						},
 						issue: {
 							number: 222,
 						},
-						type: "PullRequestReviewEvent",
+						type: "Pull-Request-Review-Event",
 					},
 				],
 			};
@@ -80,20 +80,17 @@ describe("end-to-end", () => {
 
 		expect(actual).toMatchInlineSnapshot(`
 			{
-			  "acceptedissueuser": {
+			  "accepted-issue-user": {
 			    "bug": [
 			      111,
 			    ],
 			  },
-			  "issueeventuser": {
+			  "issue-event-user": {
 			    "maintenance": [
 			      222,
 			    ],
-			    "review": [
-			      222,
-			    ],
 			  },
-			  "mergedpulluser": {
+			  "merged-pull-user": {
 			    "code": [
 			      333,
 			    ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #204
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a "unit" test that acts more as an end-to-end test. It mocks out the GitHub API and calls to the root-exported `getAllContributorsForRepository`.

Raises line coverage to near-100%, though it does miss a few bits of branch coverage. I don't feel motivated to really dive in and get true 100% branch/conditional/etc. coverage myself. That's fine as followup good first issues if anybody wants to ramp up on contributing.