### PR TITLE
docs: update README.md to turn text allcontributors to a link to https://allcontributors.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">All Contributors For Repository</h1>
 
-<p align="center">Generates an allcontributors list for an existing repository. 🤝</p>
+<p align="center">Generates an <a href="https://allcontributors.org">allcontributors</a> list for an existing repository. 🤝</p>
 
 <p align="center">
 	<a href="#contributors" target="_blank">


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #203
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updated README.md to turn text allcontributors to a link to https://allcontributors.org/
