### PR TITLE
fix: also exclude `github-actions[bot]` by default

### DIFF
--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -17,6 +17,8 @@ describe("fillInOptions", () => {
 			    "allcontributors[bot]",
 			    "dependabot",
 			    "dependabot[bot]",
+			    "github-actions",
+			    "github-actions[bot]",
 			    "renovate",
 			    "renovate[bot]",
 			  },

--- a/src/options.ts
+++ b/src/options.ts
@@ -4,6 +4,8 @@ const defaultOptions = {
 		"allcontributors[bot]",
 		"dependabot",
 		"dependabot[bot]",
+		"github-actions",
+		"github-actions[bot]",
 		"renovate",
 		"renovate[bot]",
 	],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #439
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds to the `defaultOptions.ignoredLogins` array.

💖 