### PR TITLE
feat: use octokit-from-auth for optional auth token

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 		"co-author-to-username": "^0.1.1",
 		"conventional-commits-parser": "^6.0.0",
 		"description-to-co-authors": "^0.3.0",
-		"octokit": "^4.0.0"
+		"octokit": "^4.0.0",
+		"octokit-from-auth": "^0.3.0"
 	},
 	"devDependencies": {
 		"@release-it/conventional-changelog": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       description-to-co-authors:
         specifier: ^0.3.0
         version: 0.3.0
-      get-github-auth-token:
-        specifier: ^0.1.0
-        version: 0.1.0
       octokit:
         specifier: ^4.0.0
         version: 4.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,15 @@ importers:
       description-to-co-authors:
         specifier: ^0.3.0
         version: 0.3.0
+      get-github-auth-token:
+        specifier: ^0.1.0
+        version: 0.1.0
       octokit:
         specifier: ^4.0.0
         version: 4.0.2
+      octokit-from-auth:
+        specifier: ^0.3.0
+        version: 0.3.0
     devDependencies:
       '@release-it/conventional-changelog':
         specifier: ^9.0.0
@@ -2091,6 +2097,10 @@ packages:
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
+  get-github-auth-token@0.1.0:
+    resolution: {integrity: sha512-ENm+A39AV0X4+Ls1jiCvmqx+C8hSYTv4d5hV9Ks+EL+gx9a0P9pYYpRE1k2ExwRT3EFQabGXF1Rkdp5FIsLkiw==}
+    engines: {node: '>=18'}
+
   get-stdin@9.0.0:
     resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
     engines: {node: '>=12'}
@@ -2935,6 +2945,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  octokit-from-auth@0.3.0:
+    resolution: {integrity: sha512-HeS+YVPExV5nkdRZyQQRepZVV+pL4ahVmh9KfKXLAbNc3D82G2xeuSWfKzHSIlqB1taQnZYPJWdpfcIe45d1lw==}
+    engines: {node: '>=18.3.0'}
 
   octokit@4.0.2:
     resolution: {integrity: sha512-wbqF4uc1YbcldtiBFfkSnquHtECEIpYD78YUXI6ri1Im5OO2NLo6ZVpRdbJpdnpZ05zMrVPssNiEo6JQtea+Qg==}
@@ -5946,6 +5960,8 @@ snapshots:
 
   get-func-name@2.0.2: {}
 
+  get-github-auth-token@0.1.0: {}
+
   get-stdin@9.0.0: {}
 
   get-stream@6.0.1: {}
@@ -6916,6 +6932,11 @@ snapshots:
       path-key: 4.0.0
 
   object-assign@4.1.1: {}
+
+  octokit-from-auth@0.3.0:
+    dependencies:
+      get-github-auth-token: 0.1.0
+      octokit: 4.0.2
 
   octokit@4.0.2:
     dependencies:

--- a/src/collect/api.ts
+++ b/src/collect/api.ts
@@ -1,4 +1,5 @@
 import { Octokit } from "octokit";
+import { octokitFromAuthSafe } from "octokit-from-auth";
 
 const perPage = 100;
 
@@ -7,13 +8,16 @@ export interface RequestDefaults {
 	repo: string;
 }
 
-export function createOctokit(auth: string | undefined): Octokit {
-	return new (Octokit.defaults({
+export async function createOctokit(
+	auth: string | undefined,
+): Promise<Octokit> {
+	return await octokitFromAuthSafe({
+		auth,
 		headers: {
 			"X-GitHub-Api-Version": "2022-11-28",
 		},
 		per_page: perPage,
-	}))({ auth });
+	});
 }
 
 export interface RequestOptionsWithPage extends RequestDefaults {

--- a/src/collect/index.ts
+++ b/src/collect/index.ts
@@ -13,7 +13,7 @@ export async function collect(
 	options: AllContributorsForRepositoryOptions,
 ): Promise<ContributorsContributions> {
 	const defaults = { owner: options.owner, repo: options.repo };
-	const octokit = createOctokit(options.auth);
+	const octokit = await createOctokit(options.auth);
 
 	// 1. Collect event data from the GitHub API
 	const [acceptedIssues, issueEvents, mergedPulls, repoEvents] =

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -61,13 +61,15 @@ const mockRequest = (url: string) => {
 	}
 };
 
-vi.mock("octokit", () => ({
-	get Octokit() {
-		return class MockOctokit {
+vi.mock("octokit-from-auth", () => ({
+	octokitFromAuthSafe() {
+		class MockOctokit {
 			static defaults = () => MockOctokit;
 
 			request = mockRequest;
-		};
+		}
+
+		return Promise.resolve(new MockOctokit());
 	},
 }));
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #647
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the new `octokitFromAuthSafe` function to add in an auth token if available.

💖 