### PR TITLE
fix: Prevent pagination error by reducing the number of pages requested

### DIFF
--- a/src/collect/api.test.ts
+++ b/src/collect/api.test.ts
@@ -18,42 +18,28 @@ describe("paginate", () => {
 
 	it("returns the first request's items when request returns an array the first time", async () => {
 		const request = ({ page }: RequestOptionsWithPage) =>
-			Promise.resolve(page ? [] : [{ page }]);
+			Promise.resolve(page ? [{ page }] : []);
 
 		const actual = await paginate(defaults, request);
 
-		expect(actual).toEqual([{ page: 0 }]);
+		expect(actual).toEqual([{ page: 1 }]);
 	});
 
 	it("returns multiple request items when request returns multiple times", async () => {
 		const request = ({ page }: RequestOptionsWithPage) =>
-			Promise.resolve(page < 2 ? Array(100).fill({ page }) : []);
+			Promise.resolve(page < 2 ? Array(500).fill({ page }) : []);
 
 		const actual = await paginate(defaults, request);
 
-		expect(actual).toEqual([
-			...Array(100).fill({ page: 0 }),
-			...Array(100).fill({ page: 1 }),
-		]);
+		expect(actual).toEqual([...Array(500).fill({ page: 1 })]);
 	});
 
-	it("stops retrieving after 10 requests", async () => {
+	it("stops retrieving after 2 requests", async () => {
 		const request = ({ page }: RequestOptionsWithPage) =>
-			Promise.resolve(Array(100).fill({ page }));
+			Promise.resolve(Array(500).fill({ page }));
 
 		const actual = await paginate(defaults, request);
 
-		expect(actual).toEqual([
-			...Array(100).fill({ page: 0 }),
-			...Array(100).fill({ page: 1 }),
-			...Array(100).fill({ page: 2 }),
-			...Array(100).fill({ page: 3 }),
-			...Array(100).fill({ page: 4 }),
-			...Array(100).fill({ page: 5 }),
-			...Array(100).fill({ page: 6 }),
-			...Array(100).fill({ page: 7 }),
-			...Array(100).fill({ page: 8 }),
-			...Array(100).fill({ page: 9 }),
-		]);
+		expect(actual).toEqual([...Array(500).fill({ page: 1 })]);
 	});
 });

--- a/src/collect/api.ts
+++ b/src/collect/api.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "octokit";
 import { octokitFromAuthSafe } from "octokit-from-auth";
 
-const perPage = 100;
+const perPage = 500;
 
 export interface RequestDefaults {
 	owner: string;
@@ -31,12 +31,12 @@ export async function paginate<T>(
 ) {
 	const items: T[] = [];
 
-	for (let i = 0; i < 10; i += 1) {
+	for (let i = 1; i < 2; i += 1) {
 		const response = await request({ page: i, per_page: perPage, ...defaults });
 
 		items.push(...response);
 
-		if (response.length < 100) {
+		if (response.length < perPage) {
 			break;
 		}
 	}


### PR DESCRIPTION
## PR Checklist

- [X] Addresses an existing open issue: fixes #770 
- [X] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR fixes the pagination error happening in this code when running without a PAT specified.

It achieves this by:
- Increasing the number of results per page (from 100 to 500)
- Decreasing the number of pages requested (from 10 to 1)

500 was chosen because that is what the readme in this repo claims is the maximum number of events the tool collects.

It's worth noting that this makes the pagination completely redundant because there is only ever one page. Perhaps there should be a larger number of pages chosen, or the pagination logic can be removed entirely? Previously I was running into the error on page 4 with a per_page of 100

Also: I updated the for loop to start at 1 because [the pages in the GitHub API are 1-indexed](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2026-03-10). I tested this manually by checking that `page=0` and `page=1` return the same result.

🤝