### PR TITLE
feat: add support for regular expressions for ignored logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ The exported `getAllContributorsForRepository` function takes in an object with 
 It additionally allows for the following optional options.
 
 - `auth` _(`string`)_: GitHub auth token to query the API with, if necessary for private repositories and/or to avoid rate limiting.
+- `ignoredLoginPatterns` _(`string[]`)_: Regular expression patterns for usernames to ignore commits from, such as bot users.
+  - Default: `["\\[bot\\]$"]`
 - `ignoredLogins` _(`string[]`)_: Usernames to ignore commits from, such as bot and bot-like users.
-  - Default: `"allcontributors"`, `"allcontributors[bot]"`, `"copilot"`, `"copilot[bot]"`, `"dependabot"`, `"dependabot[bot]"`, `"renovate"`, `"renovate[bot]"`
+  - Default: `["allcontributors", "copilot", "dependabot", "renovate"]`
 - `labelAcceptingPrs` _(`string`)_: Label to indicate an issue is accepting pull requests.
 - `labelTypeBug` _(`string`)_: Label to indicate an issue is for a bug.
 - `labelTypeDocs` _(`string`)_: Label to indicate an issue is for documentation.
@@ -96,6 +98,7 @@ import { getAllContributorsForRepository } from "all-contributors-for-repository
 
 getAllContributorsForRepository({
 	auth: "abc123",
+	ignoredLoginPatterns: ["-it$"],
 	ignoredLogins: ["MyBotLikeUser"],
 	labelAcceptingPrs: "help wanted",
 	labelTypeBug: "bug",

--- a/README.md
+++ b/README.md
@@ -83,10 +83,8 @@ The exported `getAllContributorsForRepository` function takes in an object with 
 It additionally allows for the following optional options.
 
 - `auth` _(`string`)_: GitHub auth token to query the API with, if necessary for private repositories and/or to avoid rate limiting.
-- `ignoredLoginPatterns` _(`string[]`)_: Regular expression patterns for usernames to ignore commits from, such as bot users.
-  - Default: `["\\[bot\\]$"]`
-- `ignoredLogins` _(`string[]`)_: Usernames to ignore commits from, such as bot and bot-like users.
-  - Default: `["allcontributors", "copilot", "dependabot", "renovate"]`
+- `ignoredLogins` _(`RegExp[]`)_: Regular expressions for usernames to ignore commits from, such as bot users.
+  - Default: `[/\[bot\]$/i, /^allcontributors$/i, /^copilot$/i, /^dependabot$/i, /^renovate$/i]`
 - `labelAcceptingPrs` _(`string`)_: Label to indicate an issue is accepting pull requests.
 - `labelTypeBug` _(`string`)_: Label to indicate an issue is for a bug.
 - `labelTypeDocs` _(`string`)_: Label to indicate an issue is for documentation.
@@ -98,8 +96,7 @@ import { getAllContributorsForRepository } from "all-contributors-for-repository
 
 getAllContributorsForRepository({
 	auth: "abc123",
-	ignoredLoginPatterns: ["-it$"],
-	ignoredLogins: ["MyBotLikeUser"],
+	ignoredLogins: [/-it$/i],
 	labelAcceptingPrs: "help wanted",
 	labelTypeBug: "bug",
 	labelTypeDocs: "docs",

--- a/src/ContributorsCollection.test.ts
+++ b/src/ContributorsCollection.test.ts
@@ -38,40 +38,8 @@ describe(ContributorsCollection, () => {
 		});
 	});
 
-	it("does not add a login contribution when its exact case is ignored", () => {
-		const contributors = new ContributorsCollection({
-			ignoredLogins: ["ignored"],
-		});
-
-		contributors.add("abc", 1, "bug");
-		contributors.add("ignored", 2, "code");
-
-		const actual = contributors.collect();
-
-		expect(actual).toEqual({
-			abc: { bug: [1] },
-		});
-	});
-
-	it("does not add a login contribution when a different case is ignored", () => {
-		const contributors = new ContributorsCollection({
-			ignoredLogins: ["Ignored"],
-		});
-
-		contributors.add("abc", 1, "bug");
-		contributors.add("ignored", 2, "code");
-
-		const actual = contributors.collect();
-
-		expect(actual).toEqual({
-			abc: { bug: [1] },
-		});
-	});
-
-	it("does not add a login contribution when a regex pattern matches", () => {
-		const contributors = new ContributorsCollection({
-			ignoredLoginPatterns: ["\\[bot\\]$"],
-		});
+	it("does not add a login contribution when the login matches an ignore regex", () => {
+		const contributors = new ContributorsCollection([/\[bot\]$/i]);
 
 		contributors.add("[bot]123", 1, "bug");
 		contributors.add("123[bot]", 2, "code");

--- a/src/ContributorsCollection.test.ts
+++ b/src/ContributorsCollection.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { ContributorsCollection } from "./ContributorsCollection.js";
 
-describe("ContributorsCollection", () => {
+describe(ContributorsCollection, () => {
 	it("produces no entries when none were added", () => {
-		const contributors = new ContributorsCollection(new Set());
+		const contributors = new ContributorsCollection();
 
 		const actual = contributors.collect();
 
@@ -12,7 +12,7 @@ describe("ContributorsCollection", () => {
 	});
 
 	it("adds a login when it is not ignored", () => {
-		const contributors = new ContributorsCollection(new Set());
+		const contributors = new ContributorsCollection();
 
 		contributors.add("abc", 0, "bug");
 
@@ -22,7 +22,7 @@ describe("ContributorsCollection", () => {
 	});
 
 	it("adds sorted contributions for logins when they are added in non-alphabetical order", () => {
-		const contributors = new ContributorsCollection(new Set());
+		const contributors = new ContributorsCollection();
 
 		contributors.add("def", 1, "tool");
 		contributors.add("abc", 2, "tool");
@@ -39,7 +39,9 @@ describe("ContributorsCollection", () => {
 	});
 
 	it("does not add a login contribution when its exact case is ignored", () => {
-		const contributors = new ContributorsCollection(new Set(["ignored"]));
+		const contributors = new ContributorsCollection({
+			ignoredLogins: ["ignored"],
+		});
 
 		contributors.add("abc", 1, "bug");
 		contributors.add("ignored", 2, "code");
@@ -52,7 +54,9 @@ describe("ContributorsCollection", () => {
 	});
 
 	it("does not add a login contribution when a different case is ignored", () => {
-		const contributors = new ContributorsCollection(new Set(["Ignored"]));
+		const contributors = new ContributorsCollection({
+			ignoredLogins: ["Ignored"],
+		});
 
 		contributors.add("abc", 1, "bug");
 		contributors.add("ignored", 2, "code");
@@ -61,6 +65,22 @@ describe("ContributorsCollection", () => {
 
 		expect(actual).toEqual({
 			abc: { bug: [1] },
+		});
+	});
+
+	it("does not add a login contribution when a regex pattern matches", () => {
+		const contributors = new ContributorsCollection({
+			ignoredLoginPatterns: ["\\[bot\\]$"],
+		});
+
+		contributors.add("[bot]123", 1, "bug");
+		contributors.add("123[bot]", 2, "code");
+		contributors.add("123[BoT]", 3, "docs");
+
+		const actual = contributors.collect();
+
+		expect(actual).toEqual({
+			"[bot]123": { bug: [1] },
 		});
 	});
 });

--- a/src/ContributorsCollection.ts
+++ b/src/ContributorsCollection.ts
@@ -13,26 +13,12 @@ export type ContributorsContributions = Record<
  */
 export type ContributorContributions = Record<string, number[]>;
 
-interface ContributorCollectionOptions {
-	ignoredLoginPatterns?: string[];
-	ignoredLogins?: string[];
-}
-
 export class ContributorsCollection {
 	#contributors: Record<string, Contributor> = {};
-	#ignoredLoginPatterns: RegExp[];
-	#ignoredLogins: Set<string>;
+	#ignoredLogins: RegExp[];
 
-	constructor({
-		ignoredLoginPatterns,
-		ignoredLogins,
-	}: ContributorCollectionOptions = {}) {
-		this.#ignoredLoginPatterns = (ignoredLoginPatterns ?? []).map(
-			(pattern) => new RegExp(pattern, "i"),
-		);
-		this.#ignoredLogins = new Set(
-			(ignoredLogins ?? []).map((login) => login.toLowerCase()),
-		);
+	constructor(ignoredLogins?: RegExp[]) {
+		this.#ignoredLogins = ignoredLogins ?? [];
 	}
 
 	add(login: string | undefined, number: number, type: string) {
@@ -41,10 +27,7 @@ export class ContributorsCollection {
 		}
 
 		const loginNormalized = login.toLowerCase();
-		if (
-			this.#ignoredLogins.has(loginNormalized) ||
-			this.#ignoredLoginPatterns.some((pattern) => pattern.test(login))
-		) {
+		if (this.#ignoredLogins.some((pattern) => pattern.test(login))) {
 			return;
 		}
 

--- a/src/ContributorsCollection.ts
+++ b/src/ContributorsCollection.ts
@@ -13,13 +13,25 @@ export type ContributorsContributions = Record<
  */
 export type ContributorContributions = Record<string, number[]>;
 
+interface ContributorCollectionOptions {
+	ignoredLoginPatterns?: string[];
+	ignoredLogins?: string[];
+}
+
 export class ContributorsCollection {
 	#contributors: Record<string, Contributor> = {};
+	#ignoredLoginPatterns: RegExp[];
 	#ignoredLogins: Set<string>;
 
-	constructor(ignoredLogins: Set<string>) {
+	constructor({
+		ignoredLoginPatterns,
+		ignoredLogins,
+	}: ContributorCollectionOptions = {}) {
+		this.#ignoredLoginPatterns = (ignoredLoginPatterns ?? []).map(
+			(pattern) => new RegExp(pattern, "i"),
+		);
 		this.#ignoredLogins = new Set(
-			Array.from(ignoredLogins).map((login) => login.toLowerCase()),
+			(ignoredLogins ?? []).map((login) => login.toLowerCase()),
 		);
 	}
 
@@ -29,7 +41,10 @@ export class ContributorsCollection {
 		}
 
 		const loginNormalized = login.toLowerCase();
-		if (this.#ignoredLogins.has(loginNormalized)) {
+		if (
+			this.#ignoredLogins.has(loginNormalized) ||
+			this.#ignoredLoginPatterns.some((pattern) => pattern.test(login))
+		) {
 			return;
 		}
 

--- a/src/collect/processing/processContributors.test.ts
+++ b/src/collect/processing/processContributors.test.ts
@@ -4,9 +4,9 @@ import { IssueEvent } from "../collecting/collectIssueEvents.js";
 import { RepoEvent } from "../collecting/collectRepoEvents.js";
 import { processContributors } from "./processContributors.js";
 
-const fakeOptions = { ignoredLogins: new Set(["ignored-login"]) };
+const fakeOptions = { ignoredLogins: ["ignored-login"] };
 
-describe("processContributors", () => {
+describe(processContributors, () => {
 	it("adds a contributor as a maintainer when they accept an issue", () => {
 		const issueId = 1;
 		const login = "abc123";

--- a/src/collect/processing/processContributors.test.ts
+++ b/src/collect/processing/processContributors.test.ts
@@ -4,7 +4,7 @@ import { IssueEvent } from "../collecting/collectIssueEvents.js";
 import { RepoEvent } from "../collecting/collectRepoEvents.js";
 import { processContributors } from "./processContributors.js";
 
-const fakeOptions = { ignoredLogins: ["ignored-login"] };
+const fakeOptions = { ignoredLogins: [/^ignored-login$/i] };
 
 describe(processContributors, () => {
 	it("adds a contributor as a maintainer when they accept an issue", () => {

--- a/src/collect/processing/processContributors.ts
+++ b/src/collect/processing/processContributors.ts
@@ -7,9 +7,12 @@ import { repoEventIsPullRequestReviewEvent } from "./repoEventIsPullRequestRevie
 export function processContributors(
 	issueEvents: IssueEvent[],
 	repoEvents: Pick<RepoEvent, "type">[],
-	options: Pick<AllContributorsForRepositoryOptions, "ignoredLogins">,
+	options: Partial<AllContributorsForRepositoryOptions>,
 ) {
-	const contributors = new ContributorsCollection(options.ignoredLogins);
+	const contributors = new ContributorsCollection({
+		ignoredLoginPatterns: options.ignoredLoginPatterns,
+		ignoredLogins: options.ignoredLogins,
+	});
 	const maintainers = new Set<string>();
 
 	for (const issueEvent of issueEvents) {

--- a/src/collect/processing/processContributors.ts
+++ b/src/collect/processing/processContributors.ts
@@ -9,10 +9,7 @@ export function processContributors(
 	repoEvents: Pick<RepoEvent, "type">[],
 	options: Partial<AllContributorsForRepositoryOptions>,
 ) {
-	const contributors = new ContributorsCollection({
-		ignoredLoginPatterns: options.ignoredLoginPatterns,
-		ignoredLogins: options.ignoredLogins,
-	});
+	const contributors = new ContributorsCollection(options.ignoredLogins);
 	const maintainers = new Set<string>();
 
 	for (const issueEvent of issueEvents) {

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -5,33 +5,31 @@ import { fillInOptions } from "./options.js";
 const owner = "fake-owner";
 const repo = "fake-repo";
 
-describe("fillInOptions", () => {
+describe(fillInOptions, () => {
 	it("fills in defaults when raw options don't provide them", () => {
 		const actual = fillInOptions({ owner, repo });
 
 		expect(actual).toMatchInlineSnapshot(`
-			{
-			  "auth": undefined,
-			  "ignoredLogins": Set {
-			    "allcontributors",
-			    "allcontributors[bot]",
-			    "copilot",
-			    "copilot[bot]",
-			    "dependabot",
-			    "dependabot[bot]",
-			    "github-actions",
-			    "github-actions[bot]",
-			    "renovate",
-			    "renovate[bot]",
-			  },
-			  "labelAcceptingPrs": "status: accepting prs",
-			  "labelTypeBug": "type: bug",
-			  "labelTypeDocs": "type: documentation",
-			  "labelTypeIdeas": "type: feature",
-			  "labelTypeTool": "area: tooling",
-			  "owner": "fake-owner",
-			  "repo": "fake-repo",
-			}
+      {
+        "auth": undefined,
+        "ignoredLoginPatterns": [
+          "\\[bot\\]$",
+        ],
+        "ignoredLogins": [
+          "allcontributors",
+          "copilot",
+          "dependabot",
+          "github-actions",
+          "renovate",
+        ],
+        "labelAcceptingPrs": "status: accepting prs",
+        "labelTypeBug": "type: bug",
+        "labelTypeDocs": "type: documentation",
+        "labelTypeIdeas": "type: feature",
+        "labelTypeTool": "area: tooling",
+        "owner": "fake-owner",
+        "repo": "fake-repo",
+      }
 		`);
 	});
 
@@ -49,9 +47,12 @@ describe("fillInOptions", () => {
 		expect(actual).toMatchInlineSnapshot(`
 			{
 			  "auth": undefined,
-			  "ignoredLogins": Set {
+			  "ignoredLoginPatterns": [
+			    "\\[bot\\]$",
+			  ],
+			  "ignoredLogins": [
 			    "abc",
-			  },
+			  ],
 			  "labelAcceptingPrs": "fake-label-accepting-prs",
 			  "labelTypeBug": "fake-label-type-bug",
 			  "labelTypeDocs": "fake-label-type-docs",

--- a/src/options.test.ts
+++ b/src/options.test.ts
@@ -12,15 +12,13 @@ describe(fillInOptions, () => {
 		expect(actual).toMatchInlineSnapshot(`
       {
         "auth": undefined,
-        "ignoredLoginPatterns": [
-          "\\[bot\\]$",
-        ],
         "ignoredLogins": [
-          "allcontributors",
-          "copilot",
-          "dependabot",
-          "github-actions",
-          "renovate",
+          /\\\\\\[bot\\\\\\]\\$/i,
+          /\\^allcontributors\\$/i,
+          /\\^copilot\\$/i,
+          /\\^dependabot\\$/i,
+          /\\^github-actions\\$/i,
+          /\\^renovate\\$/i,
         ],
         "labelAcceptingPrs": "status: accepting prs",
         "labelTypeBug": "type: bug",
@@ -35,7 +33,7 @@ describe(fillInOptions, () => {
 
 	it("uses provided options when raw options provide them", () => {
 		const actual = fillInOptions({
-			ignoredLogins: ["abc"],
+			ignoredLogins: [/abc/i],
 			labelAcceptingPrs: "fake-label-accepting-prs",
 			labelTypeBug: "fake-label-type-bug",
 			labelTypeDocs: "fake-label-type-docs",
@@ -47,11 +45,8 @@ describe(fillInOptions, () => {
 		expect(actual).toMatchInlineSnapshot(`
 			{
 			  "auth": undefined,
-			  "ignoredLoginPatterns": [
-			    "\\[bot\\]$",
-			  ],
 			  "ignoredLogins": [
-			    "abc",
+			    /abc/i,
 			  ],
 			  "labelAcceptingPrs": "fake-label-accepting-prs",
 			  "labelTypeBug": "fake-label-type-bug",

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,15 +1,11 @@
 const defaultOptions = {
+	ignoredLoginPatterns: ["\\[bot\\]$"],
 	ignoredLogins: [
 		"allcontributors",
-		"allcontributors[bot]",
 		"copilot",
-		"copilot[bot]",
 		"dependabot",
-		"dependabot[bot]",
 		"github-actions",
-		"github-actions[bot]",
 		"renovate",
-		"renovate[bot]",
 	],
 	labelAcceptingPrs: "status: accepting prs",
 	labelTypeBug: "type: bug",
@@ -20,7 +16,8 @@ const defaultOptions = {
 
 export interface AllContributorsForRepositoryOptions {
 	auth?: string;
-	ignoredLogins: Set<string>;
+	ignoredLoginPatterns: string[];
+	ignoredLogins: string[];
 	labelAcceptingPrs: string;
 	labelTypeBug: string;
 	labelTypeDocs: string;
@@ -35,6 +32,11 @@ export interface RawAllContributorsForRepositoryOptions {
 	 * GitHub auth token to query the API with, if necessary for private repositories and/or to avoid rate limiting.
 	 */
 	auth?: string;
+
+	/**
+	 * Regular expression patterns for usernames to ignore commits from, such as bot users.
+	 */
+	ignoredLoginPatterns?: string[];
 
 	/**
 	 * Usernames to ignore commits from, such as bot and bot-like users.
@@ -82,9 +84,9 @@ export function fillInOptions(
 ): AllContributorsForRepositoryOptions {
 	return {
 		auth: rawOptions.auth,
-		ignoredLogins: new Set(
-			rawOptions.ignoredLogins ?? defaultOptions.ignoredLogins,
-		),
+		ignoredLoginPatterns:
+			rawOptions.ignoredLoginPatterns ?? defaultOptions.ignoredLoginPatterns,
+		ignoredLogins: rawOptions.ignoredLogins ?? defaultOptions.ignoredLogins,
 		labelAcceptingPrs:
 			rawOptions.labelAcceptingPrs ?? defaultOptions.labelAcceptingPrs,
 		labelTypeBug: rawOptions.labelTypeBug ?? defaultOptions.labelTypeBug,

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,11 +1,11 @@
 const defaultOptions = {
-	ignoredLoginPatterns: ["\\[bot\\]$"],
 	ignoredLogins: [
-		"allcontributors",
-		"copilot",
-		"dependabot",
-		"github-actions",
-		"renovate",
+		/\[bot\]$/i,
+		/^allcontributors$/i,
+		/^copilot$/i,
+		/^dependabot$/i,
+		/^github-actions$/i,
+		/^renovate$/i,
 	],
 	labelAcceptingPrs: "status: accepting prs",
 	labelTypeBug: "type: bug",
@@ -16,8 +16,7 @@ const defaultOptions = {
 
 export interface AllContributorsForRepositoryOptions {
 	auth?: string;
-	ignoredLoginPatterns: string[];
-	ignoredLogins: string[];
+	ignoredLogins: RegExp[];
 	labelAcceptingPrs: string;
 	labelTypeBug: string;
 	labelTypeDocs: string;
@@ -34,14 +33,9 @@ export interface RawAllContributorsForRepositoryOptions {
 	auth?: string;
 
 	/**
-	 * Regular expression patterns for usernames to ignore commits from, such as bot users.
+	 * Regular expressions for usernames to ignore commits from, such as bot users.
 	 */
-	ignoredLoginPatterns?: string[];
-
-	/**
-	 * Usernames to ignore commits from, such as bot and bot-like users.
-	 */
-	ignoredLogins?: string[];
+	ignoredLogins?: RegExp[];
 
 	/**
 	 * Label to indicate an issue is accepting pull requests.
@@ -84,8 +78,6 @@ export function fillInOptions(
 ): AllContributorsForRepositoryOptions {
 	return {
 		auth: rawOptions.auth,
-		ignoredLoginPatterns:
-			rawOptions.ignoredLoginPatterns ?? defaultOptions.ignoredLoginPatterns,
 		ignoredLogins: rawOptions.ignoredLogins ?? defaultOptions.ignoredLogins,
 		labelAcceptingPrs:
 			rawOptions.labelAcceptingPrs ?? defaultOptions.labelAcceptingPrs,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to all-contributors-for-repository! 🤝.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1156 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new top level option: `ignoredLoginPatterns`, which is an array of strings, that are treated as regular expressions, and used to omit contributions by matching against the contributors login name (in the same way that `ignoredLogins` does an exact match.

The default pattern for this options is `"\\[bot\\]$"` (i.e. logins that end in `[bot]`.