### PR TITLE
test: add coverage for accepted issue with label object

### DIFF
--- a/src/collect/adding/addAcceptedIssues.test.ts
+++ b/src/collect/adding/addAcceptedIssues.test.ts
@@ -76,6 +76,17 @@ describe("addAcceptedIssues", () => {
 		expect(add).toHaveBeenCalledExactlyOnceWith(login, issue.number, "tool");
 	});
 
+	it("adds an issue when it has a label object with a matching name", () => {
+		const add = vi.fn();
+		const issue = createStubIssue({
+			labels: [{ name: options.labelTypeBug }],
+		});
+
+		addAcceptedIssues([issue], { add }, options);
+
+		expect(add).toHaveBeenCalledExactlyOnceWith(login, issue.number, "bug");
+	});
+
 	it("adds an issue's co-author when the body includes them", () => {
 		const add = vi.fn();
 		const issue = createStubIssue({


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to all-contributors-for-repository! 🤝
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #207 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/all-contributors-for-repository/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

- Adds a unit test to `addAcceptedIssues.test.ts` covering the case where a
label is an object with a `name` property, rather than a string. Previously
only the string branch of `typeof label === "string" ? label : label.name`
was exercised; this closes that coverage gap.
